### PR TITLE
add generated protos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # protos
 
 Protobuf specs for all the repos
+
+## Usage
+
+You can either compile when needed using CMake(for C++) or Prost(for Rust)
+or use `generated/`
+
+### generated: Rust
+
+- cd protos
+- install protoc(eg use prebuilt binaries, cf CI)
+- cargo install protoc-gen-prost
+- protoc -I . --prost_out=generated/rust api_circuits/api.proto api_circuits/circuits_routes.proto
+- protoc -I . --prost_out=generated/rust api_garble/api.proto api_garble/garble_routes.proto

--- a/generated/rust/interstellarpbapicircuits.rs
+++ b/generated/rust/interstellarpbapicircuits.rs
@@ -1,0 +1,48 @@
+// @generated
+/// For now it only serves to pass around what is needed TO "strip+garble"(b/c the "digits" are randomnly generated in ocw-demo)
+/// It SHOULD NOT be sent to the client, it SHOULD be kept server-side!
+///
+/// NOTE: technically we could do without b/c SkcdDisplayRequest is given "digits_bboxes" which
+/// is indeed what is used to set config\["NB_DIGITS"\].
+/// But that is cleaner to do it this way.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SkcdServerMetadata {
+    #[prost(uint32, tag="1")]
+    pub nb_digits: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SkcdDisplayRequest {
+    #[prost(uint32, tag="1")]
+    pub width: u32,
+    #[prost(uint32, tag="2")]
+    pub height: u32,
+    /// MUST match what lib_circuits's interstellar::circuits::GenerateDisplaySkcd expects
+    /// It will be converted from Vec<float> -> Vec<tuple<float>> by "generate_skcd_display"
+    #[prost(float, repeated, tag="3")]
+    pub digits_bboxes: ::prost::alloc::vec::Vec<f32>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SkcdDisplayReply {
+    #[prost(string, tag="1")]
+    pub skcd_cid: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub server_metadata: ::core::option::Option<SkcdServerMetadata>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SkcdGenericFromIpfsRequest {
+    #[prost(string, tag="1")]
+    pub verilog_cid: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SkcdGenericFromIpfsReply {
+    #[prost(string, tag="1")]
+    pub skcd_cid: ::prost::alloc::string::String,
+}
+/// Using an independent top-level well_knowns.proto does not work...
+/// <https://github.com/stepancheg/rust-protobuf/issues/409>
+/// same as google.protobuf.Empty, but directly included to avoid well-knowns
+/// [well-knowns are a pain to use with Android]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Empty {
+}
+// @@protoc_insertion_point(module)

--- a/generated/rust/interstellarpbapigarble.rs
+++ b/generated/rust/interstellarpbapigarble.rs
@@ -1,0 +1,48 @@
+// @generated
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GarbleIpfsRequest {
+    #[prost(string, tag="1")]
+    pub skcd_cid: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GarbleIpfsReply {
+    #[prost(string, tag="1")]
+    pub pgarbled_cid: ::prost::alloc::string::String,
+}
+/// For now it only serves to pass around the OTP/digits/permutation set during "strip+packmsg"
+/// It SHOULD NOT be sent to the client, it SHOULD be kept server-side!
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CircuitServerMetadata {
+    #[prost(bytes="vec", tag="1")]
+    pub digits: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GarbleAndStripIpfsRequest {
+    #[prost(string, tag="1")]
+    pub skcd_cid: ::prost::alloc::string::String,
+    /// NOTE: for now it does the 2 steps "strip" + "packmsg" in the same route but that is a bit pointless
+    /// The goal is to have a 2 steps process: garble+strip(store in DB/etc), then later packmsg using strip result from DB
+    #[prost(string, tag="2")]
+    pub tx_msg: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="3")]
+    pub server_metadata: ::core::option::Option<CircuitServerMetadata>,
+}
+/// For now we have an all-in-route that garbles then strips the circuits
+/// so we return both a Packmsg and a stripped PGC.
+/// This avoids storing a PGC somewhere then pulling it for garbling and restoring it before
+/// sending it to the user.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GarbleAndStripIpfsReply {
+    #[prost(string, tag="1")]
+    pub pgarbled_cid: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub packmsg_cid: ::prost::alloc::string::String,
+}
+/// Using an independent top-level well_knowns.proto does not work...
+/// <https://github.com/stepancheg/rust-protobuf/issues/409>
+/// same as google.protobuf.Empty, but directly included to avoid well-knowns
+/// [well-knowns are a pain to use with Android]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Empty {
+}
+// @@protoc_insertion_point(module)


### PR DESCRIPTION
Rust(prost) only for now.
Useful to avoid a build dep on prost-build with breaks in enclave/SGX.

If needed later we could also add Rust(tonic) and C++